### PR TITLE
Neuste TeX Live Version verwenden statt alte Ubuntu Paketquellen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
       go version
 
       echo "Install GitHub CLI tool hub"
-      git clone https://github.com/github/hub.git
+      git clone "https://github.com/github/hub.git"
       (
         cd hub
         ./script/build
@@ -89,10 +89,42 @@ script:
 
     fi
 
-    echo "Install dependencies for make"
-    sudo apt-get -qq update
-    sudo apt-get install -qq -y texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra latexmk
-    sudo apt-get install -qq -y biber texlive-science
+    #echo "Install possibly outdated version of TeX Live from official Ubuntu package repository"
+    #sudo apt-get -qq update
+    #sudo apt-get install -qq -y texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-science latexmk biber
+
+    echo "Install most recent version of TeX Live from CTAN"
+    TEXLIVESETUP=install-tl-unx
+    wget -q "http://mirror.ctan.org/systems/texlive/tlnet/${TEXLIVESETUP}.tar.gz"
+    mkdir -p "${TEXLIVESETUP}"
+    tar -C "./install-tl-unx/" --strip-components=1 -xzf "${TEXLIVESETUP}.tar.gz"
+    echo 'selected_scheme scheme-minimal
+          TEXDIR /tmp/texlive
+          TEXMFCONFIG ~/.texlive2015/texmf-config
+          TEXMFHOME ~/texmf
+          TEXMFLOCAL /tmp/texlive/texmf-local
+          TEXMFSYSCONFIG /tmp/texlive/texmf-config
+          TEXMFSYSVAR /tmp/texlive/texmf-var
+          TEXMFVAR ~/.texlive2015/texmf-var
+          option_doc 0
+          option_src 0' >> "./${TEXLIVESETUP}/texlive.profile"
+    (
+      cd "${TEXLIVESETUP}"
+      ./install-tl --profile=./texlive.profile
+    )
+    PATH="${PATH}:/tmp/texlive/bin/x86_64-linux"
+    tlmgr install latex latex-bin latex-fonts latexconfig collection-latexrecommended collection-fontsrecommended babel babel-english latexmk biber texliveonfly
+
+    echo "Resolve dependencies with texliveonfly"
+    texliveonfly --help
+    for TEXFILE in *.tex
+    do
+      [ -e "${TEXFILE}" ] || continue
+      [ -f "${TEXFILE}" ] || continue
+      echo "${TEXFILE} has been found"
+      texliveonfly --compiler=pdflatex --arguments="-draftmode -interaction=nonstopmode" "${TEXFILE}"
+    done
+    make clean
 
     echo "Run make"
     make

--- a/tex/discussion.tex
+++ b/tex/discussion.tex
@@ -6,7 +6,7 @@ In particular, we learned to use the coincidence method to further investigate t
 \par
 %
 Next to the many qualitative observations we made, we used prominent, known features of spectra to calibrate the channel numbers.
-We successfully detected the energies of the backscatter peak, the Compton edge and the photo peaks without significant errors compared to the theoretical values (deviation of about \SI{1}{}$\sigma$ or smaller).
+We successfully detected the energies of the backscatter peak, the Compton edge and the photo peaks without significant errors compared to the theoretical values (deviation of about \SI{1}{\sigma} or smaller).
 Here we note that the deviation is systematically larger for the Compton edge.
 This is because the marked features are edges rather than peaks so the correct channel is much harder to find.
 Still, we were able to verify the theoretical physical processes quantitatively.
@@ -45,7 +45,7 @@ Since, in reality, satisfying these requirements isn't possible, there always is
 We used the same techniques to examine the cascade decay of $^{60}\text{Co}$.
 Apart from just showing the coincidence between the two emitted photons - which is shown in figures \ref{fig:60CoEnergiewindow1} and \ref{fig:60CoKaskadenEnergiewindowBeiPeak2} - we could use the detection rates from the measurements to calculate quantitative features such as source strength and detection probability.
 These calculations are possible because it's fine to assume, that the photon emission rate is independent of the angle concerning the decay of $^{60}\text{Co}$.
-However, our calculated values deviate rather much from the theoretical value with about \SI{20}{}$\sigma$.
+However, our calculated values deviate rather much from the theoretical value with about \SI{20}{\sigma}.
 Still, the result is at least within one order of magnitude (off by a factor of $4$).
 %
 \par
@@ -58,7 +58,7 @@ The value we used for comparison could very well belong to another sample.
 \par
 %
 The other numerical value we were able to calculate is the theoretical random coincidence rate.
-Again, the value is off by around \SI{20}{}$\sigma$.
+Again, the value is off by around \SI{20}{\sigma}.
 This time, we suspect that the number of random events is determined in a flawed way.
 If we're only counting events in the tolerable channel range, we get much better results.
 This is due to the fact, that the software adds any counts exceeding the tolerance levels to the last channel.

--- a/tex/results.tex
+++ b/tex/results.tex
@@ -300,7 +300,7 @@ Additionally, the background noise of random coincidence is reduced while leavin
 \subsubsection{Energy and time window}
 %
 Having blocked all signals from counter 2 that do not fall in the energy window of the backscatter peak, the spectrum now only shows the coincident Compton peak at its expected energy of $E_{\text{exp}} = \SI{0.46 \pm 0.04}{\mega\electronvolt}$.
-The deviation to the theoretical value from above is not significant with \SI{0.35}{}$\sigma$.
+The deviation to the theoretical value from above is not significant with \SI{0.35}{\sigma}.
 The random coincidence is highly suppressed.
 %
 \subsection{Coincidence measurement of $^{60}\text{Co}$ cascade decay}
@@ -413,7 +413,7 @@ The theoretical value $Q_{\text{theo}}$ can be calculated from the half life $t_
 \par
 %
 This gives $Q_{\text{theo}} = \SI{80.4 \pm 2.4}{\kilo\becquerel}$.
-The high deviation of \SI{23}{}$\sigma$ will be discussed later.
+The high deviation of \SI{23}{\sigma} will be discussed later.
 %
 \par
 %
@@ -457,7 +457,7 @@ The theoretical value can be obtained with
 where $t_{\text{c}}$ is the time frame for coincidence depicted by the circuit.
 Because the SCA window was fully open, this means $t = \SI{2}{\micro\second}$ in our case.
 This results in $R_{\text{r}}^{\text{theo}} = \SI{3.415 \pm 0.016 e-1}{\per\second}$.
-The deviation of the values is \SI{19}{}$\sigma$.
+The deviation of the values is \SI{19}{\sigma}.
 %
 \subsubsection{Qualitative observation of coincidence}
 %


### PR DESCRIPTION
Mit der neuen Version sollte `\SI{1}{\sigma}` jetzt auch funktionieren. Bisher hat nur `\SI{1}{}$\sigma$` funktioniert.